### PR TITLE
Add portfolio features with Gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 key
 run_scripts
 .gcloudignore
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Finance Data Server
+
+This small Flask application exposes an API to fetch stock data using [yfinance](https://github.com/ranaroussi/yfinance). Requests to `/api/ticker/<symbol>` return cached data about the requested ticker. The fetched data now includes:
+
+- `info` – basic company information
+- `history` – one year of daily price history
+- `events.actions` – dividends and stock split events
+- `events.dividends` – dividend payments
+- `events.recommendations` – analyst recommendation history
+
+The server caches responses in a local SQLite database for 24 hours to limit calls to Yahoo Finance.
+The helper ``fetch_with_cache`` in ``data_fetcher.py`` encapsulates this logic and returns cached data when available.
+
+Portfolio calculations also reuse this cached ticker history so repeated requests do not refetch large datasets.
+
+## Portfolio Management
+
+Additional endpoints provide simple portfolio tracking. A Gemini API key is read
+from the ``GEMINI_API_KEY`` environment variable to allow transaction text to be
+parsed via Google Gemini.
+
+- ``POST /api/transactions/<portfolio>`` – Accepts either ``{"raw": "..."}`` or
+  ``{"transactions": [...]}``. Raw text is sent to Gemini to extract
+  standardized transactions, which are then stored in the database.
+- ``GET /api/portfolio/<portfolio>/status`` – Returns current holdings with the
+  latest market price for each asset.
+- ``GET /api/portfolio/<portfolio>/performance`` – Calculates a simple time
+  series of portfolio value based on daily closing prices.

--- a/app.py
+++ b/app.py
@@ -5,6 +5,8 @@ from functools import wraps
 import data_fetcher
 import os
 from flask_cors import CORS
+import gemini_helper
+import portfolio
 
 app = Flask(__name__)
 
@@ -51,47 +53,50 @@ def get_ticker(ticker_symbol):
     """
     ticker_symbol = ticker_symbol.upper()
 
-    # 1. Try to get data from our database (cache)
-    cached_data, last_updated = database.get_ticker_data(ticker_symbol)
+    data, source = data_fetcher.fetch_with_cache(ticker_symbol, CACHE_DURATION)
 
-    source = 'CACHE'  # To indicate where the data came from
-
-    if cached_data:
-        # Check if the cached data is still valid
-        if datetime.now() - last_updated < CACHE_DURATION:
-            print(f"Serving '{ticker_symbol}' data from CACHE.")
-            response = {
-                'source': source,
-                'ticker': ticker_symbol,
-                'data': cached_data
-            }
-            return jsonify(response)
-        else:
-            print(f"Cache for '{ticker_symbol}' is STALE. Fetching new data.")
-    else:
-        print(f"No cache found for '{ticker_symbol}'. Fetching new data.")
-
-    # 2. If no valid cache, fetch from Yahoo Finance
-    source = 'YAHOO_FINANCE_API'
-    fresh_data = data_fetcher.fetch_from_yfinance(ticker_symbol)
-
-    if not fresh_data:
+    if not data:
         return jsonify({'error': f'Could not retrieve data for ticker {ticker_symbol}'}), 404
-
-    # 3. Save the newly fetched data to our database
-    database.save_ticker_data(ticker_symbol, fresh_data)
-    print(f"Saved fresh data for '{ticker_symbol}' to database.")
 
     response = {
         'source': source,
         'ticker': ticker_symbol,
-        'data': fresh_data
+        'data': data
     }
 
     return jsonify(response)
 
 
+@app.route('/api/transactions/<string:portfolio_name>', methods=['POST'])
+def add_transactions(portfolio_name):
+    data = request.get_json(force=True)
+    raw = data.get('raw')
+    transactions = data.get('transactions')
+    if raw:
+        try:
+            transactions = gemini_helper.parse_transactions(raw)
+        except Exception as e:
+            return jsonify({'error': str(e)}), 400
+    if not transactions:
+        return jsonify({'error': 'No transactions provided'}), 400
+    database.create_portfolio(portfolio_name)
+    database.save_transactions(portfolio_name, transactions)
+    return jsonify({'status': 'saved', 'count': len(transactions)})
+
+
+@app.route('/api/portfolio/<string:portfolio_name>/status', methods=['GET'])
+def portfolio_status(portfolio_name):
+    status = portfolio.get_portfolio_status(portfolio_name)
+    return jsonify(status)
+
+
+@app.route('/api/portfolio/<string:portfolio_name>/performance', methods=['GET'])
+def portfolio_performance(portfolio_name):
+    perf = portfolio.get_performance(portfolio_name)
+    return jsonify(perf)
+
+
 if __name__ == '__main__':
     # Run the Flask app
     # In a production environment, you would use a proper WSGI server like Gunicorn
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,36 +1,64 @@
 import yfinance as yf
+from datetime import datetime, timedelta
+import database
 
 
 def fetch_from_yfinance(ticker_symbol):
-    """
-    Fetches comprehensive data for a given ticker symbol from Yahoo Finance.
-    Returns a dictionary with company info and historical data.
-    """
+    """Fetch details about a ticker using :mod:`yfinance`."""
     try:
         ticker = yf.Ticker(ticker_symbol)
 
         # Fetch company info
         info = ticker.info
 
-        # Check if the ticker is valid by looking for a key like 'shortName'
-        if not info.get('shortName'):
+        if not info.get("shortName"):
             print(f"Could not find info for ticker: {ticker_symbol}")
             return None
 
-        # Fetch historical market data for the last year
         hist = ticker.history(period="1y")
+        if not hist.empty:
+            hist.reset_index(inplace=True)
+            hist.rename(columns={"index": "Date"}, inplace=True)
+            hist["Date"] = hist["Date"].dt.strftime("%Y-%m-%d")
+            hist_dict = hist.to_dict(orient="records")
+        else:
+            hist_dict = []
 
-        # yfinance returns timestamps as timezone-aware, which can be tricky with JSON.
-        # We convert the index to simple strings.
-        hist.index = hist.index.strftime('%Y-%m-%d')
+        actions = ticker.actions
+        if not actions.empty:
+            actions.reset_index(inplace=True)
+            actions.rename(columns={"index": "Date"}, inplace=True)
+            actions["Date"] = actions["Date"].dt.strftime("%Y-%m-%d")
+            actions_dict = actions.to_dict(orient="records")
+        else:
+            actions_dict = []
 
-        # Convert DataFrame to dictionary for easy JSON serialization
-        hist_dict = hist.to_dict(orient='index')
+        dividends = ticker.dividends
+        if dividends is not None and not dividends.empty:
+            dividends = dividends.reset_index()
+            dividends.rename(columns={"index": "Date", 0: "Dividends"}, inplace=True)
+            dividends["Date"] = dividends["Date"].dt.strftime("%Y-%m-%d")
+            dividends_dict = dividends.to_dict(orient="records")
+        else:
+            dividends_dict = []
 
-        # Combine info and history into a single response object
+        recommendations = ticker.recommendations
+        if recommendations is not None and not recommendations.empty:
+            recommendations.reset_index(inplace=True)
+            recommendations.rename(columns={"index": "Date"}, inplace=True)
+            recommendations["Date"] = recommendations["Date"].dt.strftime("%Y-%m-%d")
+            recommendations_dict = recommendations.to_dict(orient="records")
+        else:
+            recommendations_dict = []
+
         response_data = {
-            'info': info,
-            'history': hist_dict
+            "info": info,
+            "history": hist_dict,
+            "events": {
+                "actions": actions_dict,
+                "dividends": dividends_dict,
+                "recommendations": recommendations_dict,
+            },
         }
 
         return response_data
@@ -38,3 +66,17 @@ def fetch_from_yfinance(ticker_symbol):
     except Exception as e:
         print(f"An error occurred while fetching data for {ticker_symbol}: {e}")
         return None
+
+
+def fetch_with_cache(ticker_symbol, cache_duration=timedelta(hours=24)):
+    """Return ticker data from cache if fresh, otherwise fetch from Yahoo Finance."""
+    cached, last_updated = database.get_ticker_data(ticker_symbol)
+    if cached and datetime.now() - last_updated < cache_duration:
+        return cached, "CACHE"
+
+    fresh = fetch_from_yfinance(ticker_symbol)
+    if fresh:
+        database.save_ticker_data(ticker_symbol, fresh)
+        return fresh, "YAHOO_FINANCE_API"
+
+    return None, None

--- a/gemini_helper.py
+++ b/gemini_helper.py
@@ -1,0 +1,29 @@
+import os
+import google.generativeai as genai
+
+API_KEY = os.getenv("GEMINI_API_KEY")
+
+def get_model():
+    if not API_KEY:
+        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+    genai.configure(api_key=API_KEY)
+    model = genai.GenerativeModel('gemini-pro')
+    return model
+
+def parse_transactions(raw_text):
+    """Use Gemini to parse raw transaction text into structured JSON."""
+    model = get_model()
+    prompt = (
+        "Extract all transactions from the text below. "
+        "Return a JSON list where each item has fields: ticker, quantity, "
+        "price, date (YYYY-MM-DD), label, and portfolio."
+    )
+    response = model.generate_content([prompt, raw_text])
+    try:
+        # Gemini returns text; we expect the JSON to be in a code block or plain
+        import json
+        cleaned = response.text.strip('`\n ')
+        return json.loads(cleaned)
+    except Exception as e:
+        raise RuntimeError(f"Failed to parse transactions: {e}")
+

--- a/portfolio.py
+++ b/portfolio.py
@@ -1,0 +1,66 @@
+from collections import defaultdict
+from datetime import datetime
+import pandas as pd
+import database
+import data_fetcher
+
+
+def get_portfolio_status(portfolio_name):
+    """Return current holdings with latest prices."""
+    txs = database.get_transactions(portfolio_name)
+    positions = database.aggregate_positions(txs)
+    holdings = []
+    total_value = 0.0
+    for ticker, qty in positions.items():
+        if qty == 0:
+            continue
+        data, _ = data_fetcher.fetch_with_cache(ticker)
+        info = data.get("info", {}) if data else {}
+        price = info.get("regularMarketPrice", 0)
+        value = price * qty
+        total_value += value
+        holdings.append({
+            "ticker": ticker,
+            "quantity": qty,
+            "price": price,
+            "value": value,
+        })
+    return {"holdings": holdings, "total_value": total_value}
+
+
+def get_performance(portfolio_name):
+    """Compute simple performance trend using daily closes."""
+    txs = database.get_transactions(portfolio_name)
+    if not txs:
+        return []
+    first_date = min(t["date"] for t in txs)
+    positions = database.aggregate_positions(txs)
+    history_dict = {}
+    for ticker, qty in positions.items():
+        if qty == 0:
+            continue
+        data, _ = data_fetcher.fetch_with_cache(ticker)
+        hist = (data or {}).get("history", [])
+        if not hist:
+            continue
+        df = pd.DataFrame(hist)
+        if df.empty or "Date" not in df.columns or "Close" not in df.columns:
+            continue
+        df["Date"] = pd.to_datetime(df["Date"])
+        df.set_index("Date", inplace=True)
+        df = df[df.index >= first_date]
+        history_dict[ticker] = df["Close"]
+    if not history_dict:
+        return []
+    df = pd.DataFrame(history_dict)
+    df.sort_index(inplace=True)
+    df.ffill(inplace=True)
+    values = []
+    for date, row in df.iterrows():
+        total = 0.0
+        for ticker, qty in positions.items():
+            price = row.get(ticker, 0)
+            total += price * qty
+        values.append({"date": date.strftime("%Y-%m-%d"), "value": total})
+    return values
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 yfinance
 Flask
 Flask-Cors
+google-generativeai==0.3.2

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,144 @@
+import unittest
+from unittest import mock
+import tempfile
+import os
+import types
+import sys
+import pandas as pd
+
+# Provide fake google.generativeai before importing gemini_helper
+fake_genai = types.ModuleType('google.generativeai')
+class DummyModel:
+    def generate_content(self, data):
+        return types.SimpleNamespace(text='[{"ticker":"AAPL","quantity":1,"price":2,"date":"2020-01-01","label":""}]')
+
+def dummy_configure(api_key=None):
+    pass
+fake_genai.GenerativeModel = lambda name: DummyModel()
+fake_genai.configure = dummy_configure
+sys.modules['google.generativeai'] = fake_genai
+os.environ['GEMINI_API_KEY'] = 'key'
+
+import database
+import data_fetcher
+import gemini_helper
+import portfolio
+
+class DatabaseTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        database.DATABASE_NAME = self.tmp.name
+        database.init_db()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_save_and_get_ticker_data(self):
+        sample = {'a': 1}
+        database.save_ticker_data('TEST', sample)
+        data, ts = database.get_ticker_data('TEST')
+        self.assertEqual(data, sample)
+        self.assertIsNotNone(ts)
+
+    def test_transactions_and_aggregate(self):
+        database.create_portfolio('p1')
+        txs = [{
+            'ticker': 'AAA',
+            'quantity': 1,
+            'price': 10,
+            'date': '2020-01-01',
+            'label': 'lab'
+        }]
+        database.save_transactions('p1', txs)
+        loaded = database.get_transactions('p1')
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0]['ticker'], 'AAA')
+        pos = database.aggregate_positions(loaded)
+        self.assertEqual(pos, {'AAA': 1.0})
+
+class DataFetcherTestCase(unittest.TestCase):
+    def setUp(self):
+        class DummyTicker:
+            def __init__(self, symbol):
+                self.info = {'shortName': 'Test', 'regularMarketPrice': 5}
+                self._history = pd.DataFrame({
+                    'Date': pd.date_range('2020-01-01', periods=2),
+                    'Close': [1, 2]
+                }).set_index('Date')
+                self._history.index.name = 'Date'
+                self.actions = pd.DataFrame({'Action': ['X']}, index=pd.to_datetime(['2020-01-01']))
+                self.actions.index.name = 'Date'
+                self.dividends = pd.DataFrame({0: [0.1]}, index=pd.to_datetime(['2020-01-01']))
+                self.recommendations = pd.DataFrame({'To Grade': ['Buy']}, index=pd.to_datetime(['2020-01-01']))
+            def history(self, period='1y'):
+                return self._history
+        self.ticker_patch = mock.patch('yfinance.Ticker', DummyTicker)
+        self.ticker_patch.start()
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        database.DATABASE_NAME = self.tmp.name
+        database.init_db()
+
+    def tearDown(self):
+        self.ticker_patch.stop()
+        os.unlink(self.tmp.name)
+
+    def test_fetch_from_yfinance(self):
+        data = data_fetcher.fetch_from_yfinance('AAA')
+        self.assertIn('info', data)
+        self.assertIn('history', data)
+        self.assertIn('events', data)
+
+    def test_fetch_with_cache(self):
+        now = pd.Timestamp.now().to_pydatetime()
+        with mock.patch('database.get_ticker_data', return_value=({'x':1}, now)):
+            data, src = data_fetcher.fetch_with_cache('AAA')
+            self.assertEqual(src, 'CACHE')
+            self.assertEqual(data, {'x':1})
+        with mock.patch('database.get_ticker_data', return_value=(None, None)), \
+             mock.patch('data_fetcher.fetch_from_yfinance', return_value={'y':2}) as fetch_mock, \
+             mock.patch('database.save_ticker_data') as save_mock:
+            data, src = data_fetcher.fetch_with_cache('BBB')
+            fetch_mock.assert_called_once()
+            save_mock.assert_called_once()
+            self.assertEqual(src, 'YAHOO_FINANCE_API')
+            self.assertEqual(data, {'y':2})
+
+class GeminiHelperTestCase(unittest.TestCase):
+    def test_get_model_and_parse(self):
+        os.environ['GEMINI_API_KEY'] = 'key'
+        model = gemini_helper.get_model()
+        self.assertTrue(hasattr(model, 'generate_content'))
+        parsed = gemini_helper.parse_transactions('text')
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(parsed[0]['ticker'], 'AAPL')
+
+class PortfolioTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        database.DATABASE_NAME = self.tmp.name
+        database.init_db()
+        txs = [
+            {'ticker': 'AAA', 'quantity': 1, 'price': 10, 'date': '2020-01-01', 'label': ''},
+            {'ticker': 'BBB', 'quantity': 2, 'price': 20, 'date': '2020-01-01', 'label': ''},
+        ]
+        database.create_portfolio('p1')
+        database.save_transactions('p1', txs)
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_portfolio_status_and_performance(self):
+        def fake_fetch(ticker, cache_duration=mock.ANY):
+            hist = [
+                {'Date': '2020-01-01', 'Close': 1 if ticker=='AAA' else 2},
+                {'Date': '2020-01-02', 'Close': 1.1 if ticker=='AAA' else 2.1},
+            ]
+            return {'info': {'regularMarketPrice': 5}, 'history': hist}, 'CACHE'
+        with mock.patch('data_fetcher.fetch_with_cache', side_effect=fake_fetch):
+            status = portfolio.get_portfolio_status('p1')
+            self.assertEqual(len(status['holdings']), 2)
+            perf = portfolio.get_performance('p1')
+            self.assertTrue(len(perf) > 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate Google Gemini via `gemini_helper`
- store user transactions and portfolios in SQLite
- compute portfolio status and performance
- expose new Flask endpoints for transactions and portfolio data
- document portfolio APIs in README
- reuse cached ticker history for portfolio calculations
- add comprehensive unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684686dccd508323ae09d20478716418